### PR TITLE
feat: replace panics with structured contracterror types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,83 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # ── Rust / Soroban contracts ──────────────────────────────────────────────
+  contracts:
+    name: Contracts
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # rust-toolchain.toml is picked up automatically by dtolnay/rust-toolchain
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+          components: rustfmt, clippy
+
+      - name: Cache Cargo registry & build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      # ── Format ──────────────────────────────────────────────────────────
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      # ── Clippy (wasm32 target, deny warnings) ───────────────────────────
+      - name: Clippy
+        run: >
+          cargo clippy
+          --all
+          --target wasm32-unknown-unknown
+          -- -D warnings
+
+      # ── Build (wasm32) ───────────────────────────────────────────────────
+      - name: Build contracts (wasm32)
+        run: cargo build --all --target wasm32-unknown-unknown --release
+
+      # ── Tests (native, testutils feature enabled via dev-deps) ──────────
+      - name: Run contract tests
+        run: cargo test --all
+
+  # ── Next.js frontend ─────────────────────────────────────────────────────
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build

--- a/contracts/carbon_credit_token/src/allowance.rs
+++ b/contracts/carbon_credit_token/src/allowance.rs
@@ -1,5 +1,6 @@
 use soroban_sdk::{Address, Env};
 
+use crate::error::Error;
 use crate::storage::{AllowanceDataKey, AllowanceValue, DataKey};
 
 pub fn read_allowance(e: &Env, from: Address, spender: Address) -> i128 {
@@ -21,39 +22,39 @@ pub fn write_allowance(
     spender: Address,
     amount: i128,
     expiration_ledger: u32,
-) {
+) -> Result<(), Error> {
+    if amount > 0 && expiration_ledger < e.ledger().sequence() {
+        return Err(Error::InvalidExpirationLedger);
+    }
+
     let allowance = AllowanceValue {
         amount,
         expiration_ledger,
     };
 
-    if amount > 0 && expiration_ledger < e.ledger().sequence() {
-        panic!("expiration_ledger is less than ledger seq when amount > 0");
-    }
-
     let key = DataKey::Allowance(AllowanceDataKey { from, spender });
     e.storage().temporary().set(&key, &allowance);
 
     if amount > 0 {
-        let live_for = expiration_ledger
-            .checked_sub(e.ledger().sequence())
-            .unwrap();
+        let live_for = expiration_ledger.saturating_sub(e.ledger().sequence());
         e.storage().temporary().extend_ttl(&key, live_for, live_for);
     }
+
+    Ok(())
 }
 
-pub fn spend_allowance(e: &Env, from: Address, spender: Address, amount: i128) {
+pub fn spend_allowance(
+    e: &Env,
+    from: Address,
+    spender: Address,
+    amount: i128,
+) -> Result<(), Error> {
     let allowance = read_allowance(e, from.clone(), spender.clone());
     if allowance < amount {
-        panic!("insufficient allowance");
+        return Err(Error::InsufficientAllowance);
     }
     if amount > 0 {
-        write_allowance(
-            e,
-            from,
-            spender,
-            allowance - amount,
-            e.ledger().sequence(),
-        );
+        write_allowance(e, from, spender, allowance - amount, e.ledger().sequence())?;
     }
+    Ok(())
 }

--- a/contracts/carbon_credit_token/src/balance.rs
+++ b/contracts/carbon_credit_token/src/balance.rs
@@ -1,5 +1,6 @@
 use soroban_sdk::{Address, Env};
 
+use crate::error::Error;
 use crate::storage::{DataKey, BALANCE_BUMP_AMOUNT, BALANCE_LIFETIME_THRESHOLD};
 
 pub fn read_balance(e: &Env, addr: Address) -> i128 {
@@ -27,10 +28,11 @@ pub fn receive_balance(e: &Env, addr: Address, amount: i128) {
     write_balance(e, addr, balance + amount);
 }
 
-pub fn spend_balance(e: &Env, addr: Address, amount: i128) {
+pub fn spend_balance(e: &Env, addr: Address, amount: i128) -> Result<(), Error> {
     let balance = read_balance(e, addr.clone());
     if balance < amount {
-        panic!("insufficient balance");
+        return Err(Error::InsufficientBalance);
     }
     write_balance(e, addr, balance - amount);
+    Ok(())
 }

--- a/contracts/carbon_credit_token/src/error.rs
+++ b/contracts/carbon_credit_token/src/error.rs
@@ -1,0 +1,19 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    /// The provided amount is negative.
+    NegativeAmount = 1,
+    /// The account does not have enough balance.
+    InsufficientBalance = 2,
+    /// The spender does not have enough allowance.
+    InsufficientAllowance = 3,
+    /// The contract has already been initialized.
+    AlreadyInitialized = 4,
+    /// The retirement amount must be greater than zero.
+    ZeroRetirementAmount = 5,
+    /// The allowance expiration ledger is in the past while amount > 0.
+    InvalidExpirationLedger = 6,
+}

--- a/contracts/carbon_credit_token/src/lib.rs
+++ b/contracts/carbon_credit_token/src/lib.rs
@@ -3,6 +3,7 @@
 mod admin;
 mod allowance;
 mod balance;
+mod error;
 mod events;
 mod metadata;
 mod storage;
@@ -13,6 +14,7 @@ use soroban_sdk::{contract, contractimpl, Address, Env, String};
 use crate::admin::{read_administrator, write_administrator};
 use crate::allowance::{read_allowance, spend_allowance, write_allowance};
 use crate::balance::{read_balance, receive_balance, spend_balance};
+use crate::error::Error;
 use crate::events::{ApproveEvent, BurnEvent, MintEvent, RetirementEvent, TransferEvent};
 use crate::metadata::{read_decimals, read_name, read_symbol, write_metadata};
 use crate::storage::{
@@ -20,9 +22,11 @@ use crate::storage::{
     write_total_supply, INSTANCE_BUMP_AMOUNT, INSTANCE_LIFETIME_THRESHOLD,
 };
 
-fn check_nonnegative_amount(amount: i128) {
+fn check_nonnegative_amount(amount: i128) -> Result<(), Error> {
     if amount < 0 {
-        panic!("negative amount is not allowed: {}", amount);
+        Err(Error::NegativeAmount)
+    } else {
+        Ok(())
     }
 }
 
@@ -33,9 +37,15 @@ pub struct CarbonCreditToken;
 impl CarbonCreditToken {
     /// Initializes the contract with admin and metadata.
     /// Can only be called once.
-    pub fn initialize(env: Env, admin: Address, name: String, symbol: String, decimals: u32) {
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        name: String,
+        symbol: String,
+        decimals: u32,
+    ) -> Result<(), Error> {
         if is_initialized(&env) {
-            panic!("contract already initialized");
+            return Err(Error::AlreadyInitialized);
         }
 
         set_initialized(&env);
@@ -43,12 +53,14 @@ impl CarbonCreditToken {
         write_metadata(&env, name, symbol, decimals);
         write_total_supply(&env, 0);
         write_total_retired(&env, 0);
+
+        Ok(())
     }
 
     /// Mints tokens to an address (Admin only).
     /// Used to credit verified donations.
-    pub fn mint(env: Env, to: Address, amount: i128) {
-        check_nonnegative_amount(amount);
+    pub fn mint(env: Env, to: Address, amount: i128) -> Result<(), Error> {
+        check_nonnegative_amount(amount)?;
 
         let admin = read_administrator(&env);
         admin.require_auth();
@@ -67,18 +79,20 @@ impl CarbonCreditToken {
             amount,
         }
         .publish(&env);
+
+        Ok(())
     }
 
     /// Transfers tokens between addresses.
-    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) -> Result<(), Error> {
         from.require_auth();
-        check_nonnegative_amount(amount);
+        check_nonnegative_amount(amount)?;
 
         env.storage()
             .instance()
             .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
 
-        spend_balance(&env, from.clone(), amount);
+        spend_balance(&env, from.clone(), amount)?;
         receive_balance(&env, to.clone(), amount);
 
         TransferEvent {
@@ -87,39 +101,49 @@ impl CarbonCreditToken {
             amount,
         }
         .publish(&env);
+
+        Ok(())
     }
 
     /// Transfers tokens using allowance.
-    pub fn transfer_from(env: Env, spender: Address, from: Address, to: Address, amount: i128) {
+    pub fn transfer_from(
+        env: Env,
+        spender: Address,
+        from: Address,
+        to: Address,
+        amount: i128,
+    ) -> Result<(), Error> {
         spender.require_auth();
-        check_nonnegative_amount(amount);
+        check_nonnegative_amount(amount)?;
 
         env.storage()
             .instance()
             .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
 
-        spend_allowance(&env, from.clone(), spender, amount);
-        spend_balance(&env, from.clone(), amount);
+        spend_allowance(&env, from.clone(), spender, amount)?;
+        spend_balance(&env, from.clone(), amount)?;
         receive_balance(&env, to.clone(), amount);
 
         TransferEvent { from, to, amount }.publish(&env);
+
+        Ok(())
     }
 
     /// Retires (burns) tokens to claim carbon offset.
     /// Emits a special RetirementEvent with timestamp.
-    pub fn retire(env: Env, from: Address, amount: i128) {
+    pub fn retire(env: Env, from: Address, amount: i128) -> Result<(), Error> {
         from.require_auth();
-        check_nonnegative_amount(amount);
+        check_nonnegative_amount(amount)?;
 
         if amount == 0 {
-            panic!("retirement amount must be greater than zero");
+            return Err(Error::ZeroRetirementAmount);
         }
 
         env.storage()
             .instance()
             .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
 
-        spend_balance(&env, from.clone(), amount);
+        spend_balance(&env, from.clone(), amount)?;
 
         let new_supply = read_total_supply(&env) - amount;
         write_total_supply(&env, new_supply);
@@ -137,41 +161,47 @@ impl CarbonCreditToken {
         .publish(&env);
 
         BurnEvent { from, amount }.publish(&env);
+
+        Ok(())
     }
 
     /// Burns tokens (SEP-41 standard).
-    pub fn burn(env: Env, from: Address, amount: i128) {
+    pub fn burn(env: Env, from: Address, amount: i128) -> Result<(), Error> {
         from.require_auth();
-        check_nonnegative_amount(amount);
+        check_nonnegative_amount(amount)?;
 
         env.storage()
             .instance()
             .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
 
-        spend_balance(&env, from.clone(), amount);
+        spend_balance(&env, from.clone(), amount)?;
 
         let new_supply = read_total_supply(&env) - amount;
         write_total_supply(&env, new_supply);
 
         BurnEvent { from, amount }.publish(&env);
+
+        Ok(())
     }
 
     /// Burns tokens using allowance.
-    pub fn burn_from(env: Env, spender: Address, from: Address, amount: i128) {
+    pub fn burn_from(env: Env, spender: Address, from: Address, amount: i128) -> Result<(), Error> {
         spender.require_auth();
-        check_nonnegative_amount(amount);
+        check_nonnegative_amount(amount)?;
 
         env.storage()
             .instance()
             .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
 
-        spend_allowance(&env, from.clone(), spender, amount);
-        spend_balance(&env, from.clone(), amount);
+        spend_allowance(&env, from.clone(), spender, amount)?;
+        spend_balance(&env, from.clone(), amount)?;
 
         let new_supply = read_total_supply(&env) - amount;
         write_total_supply(&env, new_supply);
 
         BurnEvent { from, amount }.publish(&env);
+
+        Ok(())
     }
 
     /// Approves spending by a spender (SEP-41).
@@ -181,15 +211,15 @@ impl CarbonCreditToken {
         spender: Address,
         amount: i128,
         expiration_ledger: u32,
-    ) {
+    ) -> Result<(), Error> {
         from.require_auth();
-        check_nonnegative_amount(amount);
+        check_nonnegative_amount(amount)?;
 
         env.storage()
             .instance()
             .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
 
-        write_allowance(&env, from.clone(), spender.clone(), amount, expiration_ledger);
+        write_allowance(&env, from.clone(), spender.clone(), amount, expiration_ledger)?;
 
         ApproveEvent {
             from,
@@ -198,6 +228,8 @@ impl CarbonCreditToken {
             expiration_ledger,
         }
         .publish(&env);
+
+        Ok(())
     }
 
     // ============ VIEW FUNCTIONS ============

--- a/contracts/carbon_credit_token/src/test.rs
+++ b/contracts/carbon_credit_token/src/test.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use crate::{CarbonCreditToken, CarbonCreditTokenClient};
+use crate::{error::Error, CarbonCreditToken, CarbonCreditTokenClient};
 use soroban_sdk::{
     testutils::{Address as _, Events},
     Address, Env, String,
@@ -35,6 +35,32 @@ fn test_initialize() {
     assert_eq!(token.decimals(), 0u32);
     assert_eq!(token.total_supply(), 0i128);
     assert_eq!(token.total_retired(), 0i128);
+}
+
+#[test]
+fn test_initialize_already_initialized() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, CarbonCreditToken);
+    let client = CarbonCreditTokenClient::new(&env, &contract_id);
+
+    client.initialize(
+        &admin,
+        &String::from_str(&env, "Carbon Credit Token"),
+        &String::from_str(&env, "CCT"),
+        &0u32,
+    );
+
+    let result = client.try_initialize(
+        &admin,
+        &String::from_str(&env, "Carbon Credit Token"),
+        &String::from_str(&env, "CCT"),
+        &0u32,
+    );
+
+    assert_eq!(result, Err(Ok(Error::AlreadyInitialized)));
 }
 
 // ============ MINT TESTS ============
@@ -85,6 +111,19 @@ fn test_mint_zero_amount() {
 
     assert_eq!(token.balance(&user1), 0);
     assert_eq!(token.total_supply(), 0);
+}
+
+#[test]
+fn test_mint_negative_amount_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user1 = Address::generate(&env);
+    let token = create_token(&env, &admin);
+
+    let result = token.try_mint(&user1, &-1);
+    assert_eq!(result, Err(Ok(Error::NegativeAmount)));
 }
 
 // ============ TRANSFER TESTS ============
@@ -139,6 +178,22 @@ fn test_transfer_full_balance() {
 
     assert_eq!(token.balance(&user1), 0);
     assert_eq!(token.balance(&user2), 1000);
+}
+
+#[test]
+fn test_transfer_insufficient_balance_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+    let token = create_token(&env, &admin);
+
+    token.mint(&user1, &100);
+
+    let result = token.try_transfer(&user1, &user2, &500);
+    assert_eq!(result, Err(Ok(Error::InsufficientBalance)));
 }
 
 // ============ RETIRE TESTS ============
@@ -217,6 +272,36 @@ fn test_retire_by_multiple_users() {
     assert_eq!(token.total_retired(), 500);
 }
 
+#[test]
+fn test_retire_zero_amount_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user1 = Address::generate(&env);
+    let token = create_token(&env, &admin);
+
+    token.mint(&user1, &1000);
+
+    let result = token.try_retire(&user1, &0);
+    assert_eq!(result, Err(Ok(Error::ZeroRetirementAmount)));
+}
+
+#[test]
+fn test_retire_insufficient_balance_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user1 = Address::generate(&env);
+    let token = create_token(&env, &admin);
+
+    token.mint(&user1, &100);
+
+    let result = token.try_retire(&user1, &500);
+    assert_eq!(result, Err(Ok(Error::InsufficientBalance)));
+}
+
 // ============ BURN TESTS ============
 
 #[test]
@@ -259,6 +344,21 @@ fn test_burn_vs_retire_difference() {
     assert_eq!(token.total_retired(), 200);
 }
 
+#[test]
+fn test_burn_insufficient_balance_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user1 = Address::generate(&env);
+    let token = create_token(&env, &admin);
+
+    token.mint(&user1, &100);
+
+    let result = token.try_burn(&user1, &500);
+    assert_eq!(result, Err(Ok(Error::InsufficientBalance)));
+}
+
 // ============ ALLOWANCE TESTS ============
 
 #[test]
@@ -284,6 +384,26 @@ fn test_approve_and_transfer_from() {
     assert_eq!(token.balance(&user1), 800);
     assert_eq!(token.balance(&user2), 200);
     assert_eq!(token.allowance(&user1, &spender), 300);
+}
+
+#[test]
+fn test_transfer_from_insufficient_allowance_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+    let spender = Address::generate(&env);
+    let token = create_token(&env, &admin);
+
+    token.mint(&user1, &1000);
+
+    let expiration = env.ledger().sequence() + 1000;
+    token.approve(&user1, &spender, &100, &expiration);
+
+    let result = token.try_transfer_from(&spender, &user1, &user2, &500);
+    assert_eq!(result, Err(Ok(Error::InsufficientAllowance)));
 }
 
 #[test]
@@ -326,6 +446,27 @@ fn test_approve_updates_allowance() {
     // Update allowance
     token.approve(&user1, &spender, &300, &expiration);
     assert_eq!(token.allowance(&user1, &spender), 300);
+}
+
+#[test]
+fn test_approve_expired_ledger_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user1 = Address::generate(&env);
+    let spender = Address::generate(&env);
+    let token = create_token(&env, &admin);
+
+    // expiration_ledger is in the past (sequence is 0 by default, but 0 < 0 is false,
+    // so we need sequence > expiration; bump ledger sequence first)
+    let past_ledger: u32 = 0;
+    // amount > 0 with expiration_ledger < current sequence triggers the error.
+    // Default sequence is 0, so we need to advance it.
+    env.ledger().set_sequence_number(10);
+
+    let result = token.try_approve(&user1, &spender, &100, &past_ledger);
+    assert_eq!(result, Err(Ok(Error::InvalidExpirationLedger)));
 }
 
 // ============ EDGE CASES ============

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "stable"
+targets = ["wasm32-unknown-unknown"]
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
closes #7

- Add error.rs with #[contracterror] Error enum (6 typed variants)
- Refactor balance.rs: spend_balance returns Result<(), Error>
- Refactor allowance.rs: write_allowance and spend_allowance return Result
- Refactor lib.rs: all contract methods return Result<(), Error>, propagate with ?
- Update test.rs: add error-path tests using try_* methods
- Add rust-toolchain.toml pinning stable + wasm32-unknown-unknown
- Add .github/workflows/ci.yml: fmt, clippy, wasm build, tests, frontend lint+build