### PR TITLE
fix: resolve issues #45, #53, #54 — blacklist enforcement, retirement records, TTL standardization

### DIFF
--- a/contracts/carbon_credit_token/src/lib.rs
+++ b/contracts/carbon_credit_token/src/lib.rs
@@ -8,6 +8,7 @@ mod error;
 mod events;
 mod metadata;
 mod rbac;
+mod retirement;
 mod storage;
 
 #[cfg(test)]
@@ -24,6 +25,9 @@ use crate::balance::{read_balance, receive_balance, spend_balance};
 use crate::certificate::{
     increment_next_certificate_id, read_certificate, read_next_certificate_id, write_certificate,
     CertificateRecord,
+};
+use crate::retirement::{
+    increment_next_retirement_id, read_retirement, write_retirement, RetirementRecord,
 };
 use crate::error::Error;
 use crate::events::{
@@ -159,6 +163,18 @@ impl CarbonCreditToken {
         Ok(())
     }
 
+    /// Proactively extends TTL for all critical instance storage. Admin only.
+    pub fn extend_ttl(env: Env) -> Result<(), Error> {
+        let super_admin = read_super_admin(&env);
+        super_admin.require_auth();
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+
+        Ok(())
+    }
+
     // ── Token operations ──────────────────────────────────────────────────────
 
     pub fn mint(
@@ -241,6 +257,8 @@ impl CarbonCreditToken {
         amount: i128,
         _report_hash: Bytes,
         _methodology: String,
+        reason: String,
+        beneficiary: String,
     ) -> Result<(), Error> {
         from.require_auth();
         check_nonnegative_amount(amount)?;
@@ -263,6 +281,20 @@ impl CarbonCreditToken {
         write_total_retired(&env, new_retired);
 
         let timestamp = env.ledger().timestamp();
+
+        // Store on-chain retirement record
+        let retirement_id = increment_next_retirement_id(&env);
+        write_retirement(
+            &env,
+            RetirementRecord {
+                id: retirement_id,
+                retiree: from.clone(),
+                amount,
+                timestamp,
+                reason,
+                beneficiary,
+            },
+        );
 
         // Mint Soulbound NFT Certificate
         let cert_id = increment_next_certificate_id(&env);
@@ -345,6 +377,7 @@ impl CarbonCreditToken {
         from.require_auth();
         check_nonnegative_amount(amount)?;
         require_not_blacklisted(&env, &from)?;
+        require_not_blacklisted(&env, &spender)?;
 
         env.storage()
             .instance()
@@ -400,6 +433,10 @@ impl CarbonCreditToken {
 
     pub fn get_certificate(env: Env, id: u32) -> Option<CertificateRecord> {
         read_certificate(&env, id)
+    }
+
+    pub fn get_retirement(env: Env, id: u64) -> Option<RetirementRecord> {
+        read_retirement(&env, id)
     }
 
     pub fn certificate_count(env: Env) -> u32 {

--- a/contracts/carbon_credit_token/src/retirement.rs
+++ b/contracts/carbon_credit_token/src/retirement.rs
@@ -1,0 +1,41 @@
+use soroban_sdk::{contracttype, Address, Env, String};
+
+use crate::storage::DataKey;
+
+#[derive(Clone, Debug)]
+#[contracttype]
+pub struct RetirementRecord {
+    pub id: u64,
+    pub retiree: Address,
+    pub amount: i128,
+    pub timestamp: u64,
+    pub reason: String,
+    pub beneficiary: String,
+}
+
+pub fn read_next_retirement_id(e: &Env) -> u64 {
+    e.storage()
+        .instance()
+        .get(&DataKey::NextRetirementID)
+        .unwrap_or(0u64)
+}
+
+pub fn increment_next_retirement_id(e: &Env) -> u64 {
+    let id = read_next_retirement_id(e) + 1;
+    e.storage()
+        .instance()
+        .set(&DataKey::NextRetirementID, &id);
+    id
+}
+
+pub fn write_retirement(e: &Env, record: RetirementRecord) {
+    e.storage()
+        .persistent()
+        .set(&DataKey::Retirement(record.id), &record);
+}
+
+pub fn read_retirement(e: &Env, id: u64) -> Option<RetirementRecord> {
+    e.storage()
+        .persistent()
+        .get(&DataKey::Retirement(id))
+}

--- a/contracts/carbon_credit_token/src/storage.rs
+++ b/contracts/carbon_credit_token/src/storage.rs
@@ -1,11 +1,11 @@
 use soroban_sdk::{contracttype, Address, Bytes, Env};
 
-// ── TTL Constants ──────────────────────────────────────────────────────────────
-pub const INSTANCE_LIFETIME_THRESHOLD: u32 = 17280; // ~1 day
-pub const INSTANCE_BUMP_AMOUNT: u32 = 518400; // ~30 days
+// ── TTL Constants (standardized across all contracts) ─────────────────────────
+pub const INSTANCE_LIFETIME_THRESHOLD: u32 = 17280; // ~1 day at 5s/ledger
+pub const INSTANCE_BUMP_AMOUNT: u32 = 518400; // ~30 days at 5s/ledger
 
-pub const BALANCE_LIFETIME_THRESHOLD: u32 = 17280; // ~1 day
-pub const BALANCE_BUMP_AMOUNT: u32 = 518400; // ~30 days
+pub const BALANCE_LIFETIME_THRESHOLD: u32 = 17280; // ~1 day at 5s/ledger
+pub const BALANCE_BUMP_AMOUNT: u32 = 518400; // ~30 days at 5s/ledger
 
 // ── Allowance Types ────────────────────────────────────────────────────────────
 #[derive(Clone)]
@@ -57,6 +57,10 @@ pub enum DataKey {
     // NFT Data
     NextCertificateID,
     Certificate(u32),
+
+    // Retirement Records
+    NextRetirementID,
+    Retirement(u64),
 }
 
 // ── Initialization ─────────────────────────────────────────────────────────────

--- a/contracts/rbac/src/storage.rs
+++ b/contracts/rbac/src/storage.rs
@@ -1,5 +1,9 @@
 use soroban_sdk::{contracttype, Address, Env};
 
+// ── TTL Constants (standardized across all contracts) ────────────────────────
+pub const INSTANCE_LIFETIME_THRESHOLD: u32 = 17280; // ~1 day at 5s/ledger
+pub const INSTANCE_BUMP_AMOUNT: u32 = 518400; // ~30 days at 5s/ledger
+
 // ── Role Types ───────────────────────────────────────────────────────────────
 #[derive(Clone, Copy, PartialEq, Debug, Eq)]
 #[contracttype]

--- a/contracts/verifier_registry/src/storage.rs
+++ b/contracts/verifier_registry/src/storage.rs
@@ -1,8 +1,8 @@
 use soroban_sdk::{contracttype, Address, Env, String};
 
-// TTL Constants
-pub const INSTANCE_LIFETIME_THRESHOLD: u32 = 17280; // ~1 day
-pub const INSTANCE_BUMP_AMOUNT: u32 = 518400; // ~30 days
+// TTL Constants (standardized across all contracts)
+pub const INSTANCE_LIFETIME_THRESHOLD: u32 = 17280; // ~1 day at 5s/ledger
+pub const INSTANCE_BUMP_AMOUNT: u32 = 518400; // ~30 days at 5s/ledger
 
 /// Verifier profile containing public decentralized profile information
 #[derive(Clone)]


### PR DESCRIPTION
## Summary

Resolves three open issues in a single commit.

---

### Closes #54 — Blacklist enforcement in `approve()`

Added `require_not_blacklisted` check for the **spender** in `approve()`. Previously only `from` was checked, leaving a gap where a blacklisted address could be approved as a spender.

```rust
require_not_blacklisted(&env, &from)?;
require_not_blacklisted(&env, &spender)?;  // ← added
```

---

### Closes #53 — On-chain retirement records in `retire()`

- Added `retirement.rs` with a `RetirementRecord` struct (`id`, `retiree`, `amount`, `timestamp`, `reason`, `beneficiary`).
- Extended `retire()` signature to accept `reason: String` and `beneficiary: String`.
- Each retirement is stored in persistent storage under `DataKey::Retirement(u64)`.
- Added `get_retirement(id: u64) -> Option<RetirementRecord>` query function.
- Added `DataKey::NextRetirementID` and `DataKey::Retirement(u64)` to `storage.rs`.

---

### Closes #45 — Standardized TTL constants + `extend_ttl` admin function

- Unified TTL constants across all three contracts:
  - `INSTANCE_LIFETIME_THRESHOLD = 17280` (~1 day at 5s/ledger)
  - `INSTANCE_BUMP_AMOUNT = 518400` (~30 days at 5s/ledger)
- Added matching constants to `rbac/src/storage.rs` (previously had none).
- Added `extend_ttl()` admin function to `carbon_credit_token` so the SuperAdmin can proactively bump TTL without waiting for a user transaction.

---

## Files Changed

| File | Change |
|------|--------|
| `carbon_credit_token/src/lib.rs` | spender blacklist check, retire() params, get_retirement(), extend_ttl() |
| `carbon_credit_token/src/retirement.rs` | new — RetirementRecord struct + storage helpers |
| `carbon_credit_token/src/storage.rs` | new DataKey variants, standardized TTL comments |
| `rbac/src/storage.rs` | added standardized TTL constants |
| `verifier_registry/src/storage.rs` | standardized TTL comments |