### PR TITLE
[Enhancement] Add multi-sig or governance mechanism for SuperAdmin role

### DIFF
--- a/contracts/carbon_credit_token/src/integration_test.rs
+++ b/contracts/carbon_credit_token/src/integration_test.rs
@@ -32,7 +32,8 @@ mod integration_tests {
         // Deploy the real RBAC contract.
         let rbac_id = env.register_contract(None, RbacContract);
         let rbac = RbacContractClient::new(&env, &rbac_id);
-        rbac.initialize(&super_admin);
+        let admins = soroban_sdk::vec![&env, super_admin.clone()];
+        rbac.initialize(&admins, &1u32, &0u64);
 
         // Deploy the token contract wired to the real RBAC contract.
         let token_id = env.register_contract(None, CarbonCreditToken);

--- a/contracts/rbac/src/error.rs
+++ b/contracts/rbac/src/error.rs
@@ -20,4 +20,21 @@ pub enum Error {
     InvalidRole = 7,
     /// The address already has a different role.
     AddressHasDifferentRole = 8,
+    /// Threshold must be greater than 0 and less than or equal to the number of admins.
+    InvalidThreshold = 9,
+    /// Proposal not found.
+    ProposalNotFound = 10,
+    /// Proposal has already been executed.
+    ProposalAlreadyExecuted = 11,
+    /// Proposal has been rejected/cancelled.
+    ProposalRejected = 12,
+    /// Approver has already approved this proposal.
+    AlreadyApproved = 13,
+    /// The timelock delay has not yet expired.
+    TimelockNotExpired = 14,
+    /// Insufficient approvals to execute the proposal.
+    InsufficientApprovals = 15,
+    /// Empty admin list.
+    EmptyAdmins = 16,
 }
+

--- a/contracts/rbac/src/lib.rs
+++ b/contracts/rbac/src/lib.rs
@@ -3,65 +3,330 @@
 mod error;
 mod storage;
 
+#[cfg(test)]
+mod test;
+
 pub use error::Error;
 use soroban_sdk::{contract, contractimpl, Address, Env, String, Symbol, Vec};
 
-use storage::{is_admin, read_role, read_super_admin, write_admin, write_role, write_super_admin};
+use crate::storage::{RoleType, Proposal, ProposalAction};
+
+fn execute_proposal_logic(env: &Env, action: &ProposalAction) -> Result<(), Error> {
+    match action {
+        ProposalAction::ChangeSuperAdmins { admins, threshold } => {
+            if admins.is_empty() {
+                return Err(Error::EmptyAdmins);
+            }
+            if *threshold == 0 || *threshold > admins.len() {
+                return Err(Error::InvalidThreshold);
+            }
+
+            // Revoke admin status for any removed super admins
+            let old_admins = storage::read_super_admins(env);
+            for old_admin in old_admins.iter() {
+                let mut is_still_admin = false;
+                for new_admin in admins.iter() {
+                    if new_admin == old_admin {
+                        is_still_admin = true;
+                        break;
+                    }
+                }
+                if !is_still_admin {
+                    if storage::is_super_admin(env, &old_admin) {
+                        storage::revoke_admin(env, &old_admin);
+                        storage::remove_role(env, &old_admin);
+                    }
+                }
+            }
+
+            // Write new list and threshold
+            storage::write_super_admins(env, admins);
+            storage::write_super_admin_threshold(env, *threshold);
+
+            // Assign new super admin roles
+            for admin in admins.iter() {
+                storage::write_role(env, &admin, RoleType::SuperAdmin);
+                storage::write_admin(env, &admin);
+            }
+        }
+        ProposalAction::SetTimelockDelay(delay) => {
+            storage::write_timelock_delay(env, *delay);
+        }
+        ProposalAction::GrantAdmin(account) => {
+            storage::write_admin(env, account);
+            storage::write_role(env, account, RoleType::Admin);
+        }
+        ProposalAction::RevokeAdmin(account) => {
+            if storage::is_super_admin(env, account) {
+                return Err(Error::CannotRemoveSuperAdmin);
+            }
+            storage::revoke_admin(env, account);
+            storage::remove_role(env, account);
+        }
+        ProposalAction::AssignRolesBatch(assignments) => {
+            for assignment in assignments.iter() {
+                let (account, role_str) = assignment;
+                let role_type = match role_str {
+                    r if r == Symbol::new(env, "Admin") => RoleType::Admin,
+                    r if r == Symbol::new(env, "Verifier") => RoleType::Verifier,
+                    r if r == Symbol::new(env, "Trader") => RoleType::Trader,
+                    _ => return Err(Error::InvalidRole),
+                };
+                storage::write_role(env, &account, role_type);
+                if role_type == RoleType::Admin {
+                    storage::write_admin(env, &account);
+                }
+            }
+        }
+        ProposalAction::RevokeRolesBatch(revocations) => {
+            for revocation in revocations.iter() {
+                let (account, role_str) = revocation;
+                if storage::is_super_admin(env, &account) {
+                    return Err(Error::CannotRemoveSuperAdmin);
+                }
+                let expected_role = match role_str {
+                    r if r == Symbol::new(env, "Admin") => RoleType::Admin,
+                    r if r == Symbol::new(env, "Verifier") => RoleType::Verifier,
+                    r if r == Symbol::new(env, "Trader") => RoleType::Trader,
+                    _ => return Err(Error::InvalidRole),
+                };
+                if let Some(current_role) = storage::read_role(env, &account) {
+                    if current_role == expected_role {
+                        match current_role {
+                            RoleType::Admin => {
+                                storage::revoke_admin(env, &account);
+                                storage::remove_role(env, &account);
+                            }
+                            RoleType::Verifier => {
+                                storage::revoke_verifier(env, &account);
+                            }
+                            RoleType::Trader => {
+                                storage::revoke_trader(env, &account);
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
 
 #[contract]
 pub struct RbacContract;
 
 #[contractimpl]
 impl RbacContract {
-    /// Initializes the contract with a SuperAdmin.
-    pub fn initialize(env: Env, admin: Address) -> Result<(), Error> {
+    /// Initializes the contract with the initial list of SuperAdmins, threshold, and timelock delay.
+    pub fn initialize(
+        env: Env,
+        admins: Vec<Address>,
+        threshold: u32,
+        timelock_delay: u64,
+    ) -> Result<(), Error> {
         if storage::is_initialized(&env) {
             return Err(Error::AlreadyInitialized);
         }
+        if admins.is_empty() {
+            return Err(Error::EmptyAdmins);
+        }
+        if threshold == 0 || threshold > admins.len() {
+            return Err(Error::InvalidThreshold);
+        }
+
         storage::set_initialized(&env);
-        write_super_admin(&env, &admin);
-        write_admin(&env, &admin);
-        write_role(&env, &admin, storage::RoleType::SuperAdmin);
+        storage::write_super_admins(&env, &admins);
+        storage::write_super_admin_threshold(&env, threshold);
+        storage::write_timelock_delay(&env, timelock_delay);
+
+        for admin in admins.iter() {
+            storage::write_admin(&env, &admin);
+            storage::write_role(&env, &admin, RoleType::SuperAdmin);
+        }
 
         Ok(())
+    }
+
+    // --- Governance Proposal API ---
+
+    /// Proposes a multi-sig action.
+    /// Only a SuperAdmin can call this.
+    pub fn propose_action(
+        env: Env,
+        proposer: Address,
+        action: ProposalAction,
+    ) -> Result<u64, Error> {
+        proposer.require_auth();
+        if !storage::is_super_admin(&env, &proposer) {
+            return Err(Error::Unauthorized);
+        }
+
+        let next_id = storage::read_next_proposal_id(&env);
+        let created_at = env.ledger().timestamp();
+
+        let mut approvals = Vec::new(&env);
+        approvals.push_back(proposer.clone());
+
+        let mut proposal = Proposal {
+            id: next_id,
+            action: action.clone(),
+            proposer: proposer.clone(),
+            approvals,
+            created_at,
+            executed: false,
+            rejected: false,
+        };
+
+        storage::write_next_proposal_id(&env, next_id + 1);
+
+        let threshold = storage::read_super_admin_threshold(&env);
+        let timelock_delay = storage::read_timelock_delay(&env);
+
+        if threshold == 1 && timelock_delay == 0 {
+            execute_proposal_logic(&env, &action)?;
+            proposal.executed = true;
+        }
+
+        storage::write_proposal(&env, next_id, &proposal);
+
+        Ok(next_id)
+    }
+
+    /// Approves an existing proposal.
+    /// Only a SuperAdmin can call this.
+    pub fn approve_proposal(
+        env: Env,
+        approver: Address,
+        proposal_id: u64,
+    ) -> Result<(), Error> {
+        approver.require_auth();
+        if !storage::is_super_admin(&env, &approver) {
+            return Err(Error::Unauthorized);
+        }
+
+        let mut proposal = storage::read_proposal(&env, proposal_id).ok_or(Error::ProposalNotFound)?;
+
+        if proposal.executed {
+            return Err(Error::ProposalAlreadyExecuted);
+        }
+        if proposal.rejected {
+            return Err(Error::ProposalRejected);
+        }
+
+        for app in proposal.approvals.iter() {
+            if app == approver {
+                return Err(Error::AlreadyApproved);
+            }
+        }
+
+        proposal.approvals.push_back(approver);
+        storage::write_proposal(&env, proposal_id, &proposal);
+
+        Ok(())
+    }
+
+    /// Executes an approved proposal after the timelock has expired.
+    /// Can be called by anyone.
+    pub fn execute_proposal(
+        env: Env,
+        proposal_id: u64,
+    ) -> Result<(), Error> {
+        let mut proposal = storage::read_proposal(&env, proposal_id).ok_or(Error::ProposalNotFound)?;
+
+        if proposal.executed {
+            return Err(Error::ProposalAlreadyExecuted);
+        }
+        if proposal.rejected {
+            return Err(Error::ProposalRejected);
+        }
+
+        let threshold = storage::read_super_admin_threshold(&env);
+        if proposal.approvals.len() < threshold {
+            return Err(Error::InsufficientApprovals);
+        }
+
+        let timelock_delay = storage::read_timelock_delay(&env);
+        if env.ledger().timestamp() < proposal.created_at + timelock_delay {
+            return Err(Error::TimelockNotExpired);
+        }
+
+        execute_proposal_logic(&env, &proposal.action)?;
+
+        proposal.executed = true;
+        storage::write_proposal(&env, proposal_id, &proposal);
+
+        Ok(())
+    }
+
+    /// Vetoes/cancels a proposal.
+    /// Only a SuperAdmin can call this.
+    pub fn reject_proposal(
+        env: Env,
+        rejecter: Address,
+        proposal_id: u64,
+    ) -> Result<(), Error> {
+        rejecter.require_auth();
+        if !storage::is_super_admin(&env, &rejecter) {
+            return Err(Error::Unauthorized);
+        }
+
+        let mut proposal = storage::read_proposal(&env, proposal_id).ok_or(Error::ProposalNotFound)?;
+
+        if proposal.executed {
+            return Err(Error::ProposalAlreadyExecuted);
+        }
+        if proposal.rejected {
+            return Err(Error::ProposalRejected);
+        }
+
+        proposal.rejected = true;
+        storage::write_proposal(&env, proposal_id, &proposal);
+
+        Ok(())
+    }
+
+    /// Returns a proposal by ID.
+    pub fn get_proposal(env: Env, proposal_id: u64) -> Option<Proposal> {
+        storage::read_proposal(&env, proposal_id)
     }
 
     // --- Role Management ---
 
     pub fn grant_admin(env: Env, admin: Address, account: Address) -> Result<(), Error> {
         admin.require_auth();
-        if !is_admin(&env, &admin) {
+        if !storage::is_admin(&env, &admin) {
             return Err(Error::Unauthorized);
         }
-        write_admin(&env, &account);
-        write_role(&env, &account, storage::RoleType::Admin);
+        storage::write_admin(&env, &account);
+        storage::write_role(&env, &account, RoleType::Admin);
 
         Ok(())
     }
 
     pub fn grant_verifier(env: Env, admin: Address, account: Address) -> Result<(), Error> {
         admin.require_auth();
-        if !is_admin(&env, &admin) {
+        if !storage::is_admin(&env, &admin) {
             return Err(Error::Unauthorized);
         }
-        write_role(&env, &account, storage::RoleType::Verifier);
+        storage::write_role(&env, &account, RoleType::Verifier);
 
         Ok(())
     }
 
     pub fn grant_trader(env: Env, admin: Address, account: Address) -> Result<(), Error> {
         admin.require_auth();
-        if !is_admin(&env, &admin) {
+        if !storage::is_admin(&env, &admin) {
             return Err(Error::Unauthorized);
         }
-        write_role(&env, &account, storage::RoleType::Trader);
+        storage::write_role(&env, &account, RoleType::Trader);
 
         Ok(())
     }
 
     pub fn revoke_role(env: Env, admin: Address, account: Address) -> Result<(), Error> {
         admin.require_auth();
-        if !is_admin(&env, &admin) {
+        if !storage::is_admin(&env, &admin) {
             return Err(Error::Unauthorized);
         }
 
@@ -69,105 +334,79 @@ impl RbacContract {
             return Err(Error::CannotRemoveSuperAdmin);
         }
 
-        match read_role(&env, &account) {
-            Some(storage::RoleType::Admin) => {
+        match storage::read_role(&env, &account) {
+            Some(RoleType::Admin) => {
                 storage::revoke_admin(&env, &account);
                 storage::remove_role(&env, &account);
                 Ok(())
             }
-            Some(storage::RoleType::Verifier) => {
+            Some(RoleType::Verifier) => {
                 storage::revoke_verifier(&env, &account);
                 Ok(())
             }
-            Some(storage::RoleType::Trader) => {
+            Some(RoleType::Trader) => {
                 storage::revoke_trader(&env, &account);
                 Ok(())
             }
-            Some(storage::RoleType::SuperAdmin) => Err(Error::CannotRemoveSuperAdmin),
+            Some(RoleType::SuperAdmin) => Err(Error::CannotRemoveSuperAdmin),
             None => Err(Error::RoleNotAssigned),
         }
     }
 
-    // --- Batch Operations ---
+    // --- Batch Operations (Redirected or single-admin only) ---
 
-    pub fn assign_roles_batch(env: Env, super_admin: Address, assignments: Vec<(Address, Symbol)>) -> Result<(), Error> {
+    pub fn assign_roles_batch(
+        env: Env,
+        super_admin: Address,
+        assignments: Vec<(Address, Symbol)>,
+    ) -> Result<(), Error> {
+        let threshold = storage::read_super_admin_threshold(&env);
+        if threshold > 1 {
+            return Err(Error::Unauthorized); // Must go through proposal flow when threshold > 1
+        }
+
         super_admin.require_auth();
         if !storage::is_super_admin(&env, &super_admin) {
             return Err(Error::Unauthorized);
         }
 
-        for assignment in assignments.iter() {
-            let (account, role_str) = assignment;
-            let role_type = match role_str {
-                r if r == Symbol::new(&env, "Admin") => storage::RoleType::Admin,
-                r if r == Symbol::new(&env, "Verifier") => storage::RoleType::Verifier,
-                r if r == Symbol::new(&env, "Trader") => storage::RoleType::Trader,
-                _ => return Err(Error::InvalidRole),
-            };
-            write_role(&env, &account, role_type);
-            if role_type == storage::RoleType::Admin {
-                write_admin(&env, &account);
-            }
-        }
-
-        Ok(())
+        execute_proposal_logic(&env, &ProposalAction::AssignRolesBatch(assignments))
     }
 
-    pub fn revoke_roles_batch(env: Env, super_admin: Address, revocations: Vec<(Address, Symbol)>) -> Result<(), Error> {
+    pub fn revoke_roles_batch(
+        env: Env,
+        super_admin: Address,
+        revocations: Vec<(Address, Symbol)>,
+    ) -> Result<(), Error> {
+        let threshold = storage::read_super_admin_threshold(&env);
+        if threshold > 1 {
+            return Err(Error::Unauthorized); // Must go through proposal flow when threshold > 1
+        }
+
         super_admin.require_auth();
         if !storage::is_super_admin(&env, &super_admin) {
             return Err(Error::Unauthorized);
         }
 
-        for revocation in revocations.iter() {
-            let (account, role_str) = revocation;
-            if storage::is_super_admin(&env, &account) {
-                return Err(Error::CannotRemoveSuperAdmin);
-            }
-            let expected_role = match role_str {
-                r if r == Symbol::new(&env, "Admin") => storage::RoleType::Admin,
-                r if r == Symbol::new(&env, "Verifier") => storage::RoleType::Verifier,
-                r if r == Symbol::new(&env, "Trader") => storage::RoleType::Trader,
-                _ => return Err(Error::InvalidRole),
-            };
-            if let Some(current_role) = read_role(&env, &account) {
-                if current_role == expected_role {
-                    match current_role {
-                        storage::RoleType::Admin => {
-                            storage::revoke_admin(&env, &account);
-                            storage::remove_role(&env, &account);
-                        }
-                        storage::RoleType::Verifier => {
-                            storage::revoke_verifier(&env, &account);
-                        }
-                        storage::RoleType::Trader => {
-                            storage::revoke_trader(&env, &account);
-                        }
-                        _ => {}
-                    }
-                }
-            }
-        }
-
-        Ok(())
+        execute_proposal_logic(&env, &ProposalAction::RevokeRolesBatch(revocations))
     }
 
     // --- Role Checks ---
 
     pub fn has_role(env: Env, account: Address, role: String) -> bool {
         let role_type = if role == String::from_str(&env, "Admin") {
-            storage::RoleType::Admin
+            RoleType::Admin
         } else if role == String::from_str(&env, "Verifier") {
-            storage::RoleType::Verifier
+            RoleType::Verifier
         } else if role == String::from_str(&env, "Trader") {
-            storage::RoleType::Trader
+            RoleType::Trader
         } else if role == String::from_str(&env, "SuperAdmin") {
-            storage::RoleType::SuperAdmin
+            RoleType::SuperAdmin
         } else {
             return false;
         };
 
-        if let Some(assigned) = read_role(&env, &account) {
+        if let Some(assigned) = storage::read_role(&env, &account) {
             assigned == role_type
         } else {
             false
@@ -175,17 +414,51 @@ impl RbacContract {
     }
 
     pub fn is_admin(env: Env, account: Address) -> bool {
-        is_admin(&env, &account)
+        storage::is_admin(&env, &account)
     }
 
     pub fn transfer_admin(env: Env, new_admin: Address) -> Result<(), Error> {
-        let super_admin = read_super_admin(&env);
-        super_admin.require_auth();
+        let admins = storage::read_super_admins(&env);
+        let threshold = storage::read_super_admin_threshold(&env);
 
-        write_super_admin(&env, &new_admin);
-        write_admin(&env, &new_admin);
-        write_role(&env, &new_admin, storage::RoleType::SuperAdmin);
+        if threshold > 1 {
+            return Err(Error::Unauthorized); // Must go through proposal flow when threshold > 1
+        }
+
+        let caller = admins.get(0).ok_or(Error::Unauthorized)?;
+        caller.require_auth();
+
+        // Clean up old super admin roles
+        for old_admin in admins.iter() {
+            if old_admin != new_admin {
+                storage::revoke_admin(&env, &old_admin);
+                storage::remove_role(&env, &old_admin);
+            }
+        }
+
+        // Set new single super admin
+        let mut new_admins = Vec::new(&env);
+        new_admins.push_back(new_admin.clone());
+        storage::write_super_admins(&env, &new_admins);
+        storage::write_super_admin_threshold(&env, 1);
+
+        storage::write_role(&env, &new_admin, RoleType::SuperAdmin);
+        storage::write_admin(&env, &new_admin);
 
         Ok(())
+    }
+
+    pub fn get_super_admin(env: Env) -> Address {
+        storage::read_super_admin(&env)
+    }
+
+    pub fn get_role(env: Env, address: Address) -> u32 {
+        match storage::read_role(&env, &address) {
+            Some(RoleType::SuperAdmin) => 0,
+            Some(RoleType::Verifier) => 1,
+            Some(RoleType::Trader) => 2,
+            Some(RoleType::Admin) => 3,
+            None => 255,
+        }
     }
 }

--- a/contracts/rbac/src/storage.rs
+++ b/contracts/rbac/src/storage.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Address, Env};
+use soroban_sdk::{contracttype, Address, Env, Vec, Symbol};
 
 // ── TTL Constants (standardized across all contracts) ────────────────────────
 pub const INSTANCE_LIFETIME_THRESHOLD: u32 = 17280; // ~1 day at 5s/ledger
@@ -14,14 +14,42 @@ pub enum RoleType {
     Trader,
 }
 
+// ── Governance Types ─────────────────────────────────────────────────────────
+#[derive(Clone, Debug, PartialEq)]
+#[contracttype]
+pub enum ProposalAction {
+    ChangeSuperAdmins { admins: Vec<Address>, threshold: u32 },
+    SetTimelockDelay(u64),
+    GrantAdmin(Address),
+    RevokeAdmin(Address),
+    AssignRolesBatch(Vec<(Address, Symbol)>),
+    RevokeRolesBatch(Vec<(Address, Symbol)>),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+#[contracttype]
+pub struct Proposal {
+    pub id: u64,
+    pub action: ProposalAction,
+    pub proposer: Address,
+    pub approvals: Vec<Address>,
+    pub created_at: u64,
+    pub executed: bool,
+    pub rejected: bool,
+}
+
 // ── Storage Keys ─────────────────────────────────────────────────────────────
 #[derive(Clone)]
 #[contracttype]
 pub enum DataKey {
     Initialized,
-    SuperAdmin,
+    SuperAdmins,
+    SuperAdminThreshold,
+    TimelockDelay,
     Admin(Address), // Map of addresses with Admin role
     Role(Address),
+    NextProposalId,
+    Proposal(u64),
 }
 
 // ── Initialization ────────────────────────────────────────────────────────────
@@ -33,16 +61,73 @@ pub fn set_initialized(e: &Env) {
     e.storage().instance().set(&DataKey::Initialized, &true);
 }
 
-// ── SuperAdmin ────────────────────────────────────────────────────────────────
-pub fn read_super_admin(e: &Env) -> Address {
+// ── SuperAdmins List ─────────────────────────────────────────────────────────
+pub fn read_super_admins(e: &Env) -> Vec<Address> {
     e.storage()
         .instance()
-        .get(&DataKey::SuperAdmin)
-        .expect("super admin not set")
+        .get(&DataKey::SuperAdmins)
+        .expect("super admins not set")
+}
+
+pub fn write_super_admins(e: &Env, admins: &Vec<Address>) {
+    e.storage().instance().set(&DataKey::SuperAdmins, admins);
+}
+
+pub fn read_super_admin_threshold(e: &Env) -> u32 {
+    e.storage()
+        .instance()
+        .get(&DataKey::SuperAdminThreshold)
+        .unwrap_or(1)
+}
+
+pub fn write_super_admin_threshold(e: &Env, threshold: u32) {
+    e.storage()
+        .instance()
+        .set(&DataKey::SuperAdminThreshold, &threshold);
+}
+
+pub fn read_timelock_delay(e: &Env) -> u64 {
+    e.storage()
+        .instance()
+        .get(&DataKey::TimelockDelay)
+        .unwrap_or(0)
+}
+
+pub fn write_timelock_delay(e: &Env, delay: u64) {
+    e.storage().instance().set(&DataKey::TimelockDelay, &delay);
+}
+
+// ── Proposals ─────────────────────────────────────────────────────────────────
+pub fn read_next_proposal_id(e: &Env) -> u64 {
+    e.storage()
+        .instance()
+        .get(&DataKey::NextProposalId)
+        .unwrap_or(1)
+}
+
+pub fn write_next_proposal_id(e: &Env, id: u64) {
+    e.storage().instance().set(&DataKey::NextProposalId, &id);
+}
+
+pub fn read_proposal(e: &Env, id: u64) -> Option<Proposal> {
+    e.storage().persistent().get(&DataKey::Proposal(id))
+}
+
+pub fn write_proposal(e: &Env, id: u64, proposal: &Proposal) {
+    e.storage().persistent().set(&DataKey::Proposal(id), proposal);
+}
+
+// ── SuperAdmin (Legacy Compatibility) ─────────────────────────────────────────
+pub fn read_super_admin(e: &Env) -> Address {
+    let admins = read_super_admins(e);
+    admins.get(0).expect("super admin not set")
 }
 
 pub fn write_super_admin(e: &Env, admin: &Address) {
-    e.storage().instance().set(&DataKey::SuperAdmin, admin);
+    let mut admins = Vec::new(e);
+    admins.push_back(admin.clone());
+    write_super_admins(e, &admins);
+    write_super_admin_threshold(e, 1);
 }
 
 // ── Role Helpers ──────────────────────────────────────────────────────────────
@@ -96,3 +181,4 @@ pub fn is_admin(e: &Env, address: &Address) -> bool {
         Some(RoleType::SuperAdmin) | Some(RoleType::Admin)
     )
 }
+

--- a/contracts/rbac/src/test.rs
+++ b/contracts/rbac/src/test.rs
@@ -1,277 +1,302 @@
 #![cfg(test)]
 
-use soroban_sdk::{testutils::Address as _, Address, Env, String};
+use soroban_sdk::{testutils::{Address as _, Ledger}, Address, Env, String, Symbol, vec};
 
 use crate::{error::Error, RbacContract, RbacContractClient};
+use crate::storage::{ProposalAction, RoleType};
 
-// ── Test Helpers ───────────────────────────────────────────────────────────────
-
-fn setup() -> (Env, RbacContractClient<'static>, Address) {
-    let env = Env::default();
-    env.mock_all_auths();
-
+fn setup_single(env: &Env) -> (RbacContractClient<'static>, Address) {
     let contract_id = env.register_contract(None, RbacContract);
-    let client = RbacContractClient::new(&env, &contract_id);
+    let client = RbacContractClient::new(env, &contract_id);
 
-    let super_admin = Address::generate(&env);
-    client.initialize(&super_admin);
+    let super_admin = Address::generate(env);
+    let admins = vec![env, super_admin.clone()];
+    client.initialize(&admins, &1u32, &0u64);
 
-    (env, client, super_admin)
+    (client, super_admin)
 }
 
-// ── Initialization ─────────────────────────────────────────────────────────────
+fn setup_multi(env: &Env, threshold: u32, delay: u64) -> (RbacContractClient<'static>, soroban_sdk::Vec<Address>) {
+    let contract_id = env.register_contract(None, RbacContract);
+    let client = RbacContractClient::new(env, &contract_id);
+
+    let admin1 = Address::generate(env);
+    let admin2 = Address::generate(env);
+    let admin3 = Address::generate(env);
+    let admins = vec![env, admin1.clone(), admin2.clone(), admin3.clone()];
+    client.initialize(&admins, &threshold, &delay);
+
+    (client, admins)
+}
+
+// ── Initialization Tests ──────────────────────────────────────────────────────
 
 #[test]
-fn test_initialize_sets_super_admin() {
-    let (_, client, super_admin) = setup();
+fn test_initialize_sets_super_admins() {
+    let env = Env::default();
+    let (client, super_admin) = setup_single(&env);
     assert_eq!(client.get_super_admin(), super_admin);
-    assert!(client.is_super_admin(&super_admin));
+    assert!(client.has_role(&super_admin, &String::from_str(&env, "SuperAdmin")));
+    assert!(client.is_admin(&super_admin));
     assert_eq!(client.get_role(&super_admin), 0u32);
 }
 
 #[test]
 fn test_initialize_twice_fails() {
-    let (env, client, _) = setup();
+    let env = Env::default();
+    let (client, super_admin) = setup_single(&env);
     let other = Address::generate(&env);
-    let result = client.try_initialize(&other);
+    let admins = vec![&env, other];
+    let result = client.try_initialize(&admins, &1u32, &0u64);
     assert_eq!(result, Err(Ok(Error::AlreadyInitialized)));
 }
 
-// ── get_role ───────────────────────────────────────────────────────────────────
-
 #[test]
-fn test_get_role_returns_255_for_unknown() {
-    let (env, client, _) = setup();
-    let unknown = Address::generate(&env);
-    assert_eq!(client.get_role(&unknown), 255u32);
+fn test_initialize_invalid_threshold() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, RbacContract);
+    let client = RbacContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let admins = vec![&env, admin];
+    
+    // Threshold = 0 fails
+    let res1 = client.try_initialize(&admins, &0u32, &0u64);
+    assert_eq!(res1, Err(Ok(Error::InvalidThreshold)));
+
+    // Threshold > admins.len() fails
+    let res2 = client.try_initialize(&admins, &2u32, &0u64);
+    assert_eq!(res2, Err(Ok(Error::InvalidThreshold)));
 }
 
-#[test]
-fn test_get_role_super_admin_is_0() {
-    let (_, client, super_admin) = setup();
-    assert_eq!(client.get_role(&super_admin), 0u32);
-}
+// ── Role Management Tests (Single Admin Mode) ──────────────────────────────────
 
 #[test]
-fn test_get_role_verifier_is_1() {
-    let (env, client, _) = setup();
+fn test_role_management_single_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, super_admin) = setup_single(&env);
+
     let verifier = Address::generate(&env);
-    client.add_verifier(&verifier);
-    assert_eq!(client.get_role(&verifier), 1u32);
-}
-
-#[test]
-fn test_get_role_trader_is_2() {
-    let (env, client, _) = setup();
     let trader = Address::generate(&env);
-    client.add_trader(&trader);
-    assert_eq!(client.get_role(&trader), 2u32);
-}
+    let admin = Address::generate(&env);
 
-// ── Verifier ───────────────────────────────────────────────────────────────────
-
-#[test]
-fn test_add_and_check_verifier() {
-    let (env, client, _) = setup();
-    let verifier = Address::generate(&env);
-
-    client.add_verifier(&verifier);
-
-    assert!(client.is_verifier(&verifier));
-    assert_eq!(client.get_role(&verifier), 1u32);
-}
-
-#[test]
-fn test_add_verifier_twice_fails() {
-    let (env, client, _) = setup();
-    let verifier = Address::generate(&env);
-
-    client.add_verifier(&verifier);
-    let result = client.try_add_verifier(&verifier);
-    assert_eq!(result, Err(Ok(Error::RoleAlreadyAssigned)));
-}
-
-#[test]
-fn test_remove_verifier() {
-    let (env, client, _) = setup();
-    let verifier = Address::generate(&env);
-
-    client.add_verifier(&verifier);
-    assert!(client.is_verifier(&verifier));
-
-    client.remove_verifier(&verifier);
-    assert!(!client.is_verifier(&verifier));
-    assert_eq!(client.get_role(&verifier), 255u32);
-}
-
-#[test]
-fn test_remove_nonexistent_verifier_fails() {
-    let (env, client, _) = setup();
-    let nobody = Address::generate(&env);
-    let result = client.try_remove_verifier(&nobody);
-    assert_eq!(result, Err(Ok(Error::RoleNotAssigned)));
-}
-
-#[test]
-fn test_super_admin_cannot_be_added_as_verifier() {
-    let (_, client, super_admin) = setup();
-    let result = client.try_add_verifier(&super_admin);
-    assert_eq!(result, Err(Ok(Error::AddressHasDifferentRole)));
-}
-
-#[test]
-fn test_multiple_verifiers() {
-    let (env, client, _) = setup();
-
-    let verifier1 = Address::generate(&env);
-    let verifier2 = Address::generate(&env);
-    let verifier3 = Address::generate(&env);
-
-    client.add_verifier(&verifier1);
-    client.add_verifier(&verifier2);
-    client.add_verifier(&verifier3);
-
-    assert!(client.is_verifier(&verifier1));
-    assert!(client.is_verifier(&verifier2));
-    assert!(client.is_verifier(&verifier3));
-}
-
-// ── Trader ─────────────────────────────────────────────────────────────────────
-
-#[test]
-fn test_add_and_check_trader() {
-    let (env, client, _) = setup();
-    let trader = Address::generate(&env);
-
-    client.add_trader(&trader);
-
-    assert!(client.is_trader(&trader));
-    assert_eq!(client.get_role(&trader), 2u32);
-}
-
-#[test]
-fn test_add_trader_twice_fails() {
-    let (env, client, _) = setup();
-    let trader = Address::generate(&env);
-
-    client.add_trader(&trader);
-    let result = client.try_add_trader(&trader);
-    assert_eq!(result, Err(Ok(Error::RoleAlreadyAssigned)));
-}
-
-#[test]
-fn test_remove_trader() {
-    let (env, client, _) = setup();
-    let trader = Address::generate(&env);
-
-    client.add_trader(&trader);
-    client.remove_trader(&trader);
-
-    assert!(!client.is_trader(&trader));
-    assert_eq!(client.get_role(&trader), 255u32);
-}
-
-#[test]
-fn test_remove_trader_not_assigned() {
-    let (env, client, _) = setup();
-    let trader = Address::generate(&env);
-    let result = client.try_remove_trader(&trader);
-    assert_eq!(result, Err(Ok(Error::RoleNotAssigned)));
-}
-
-#[test]
-fn test_multiple_traders() {
-    let (env, client, _) = setup();
-
-    let trader1 = Address::generate(&env);
-    let trader2 = Address::generate(&env);
-
-    client.add_trader(&trader1);
-    client.add_trader(&trader2);
-
-    assert!(client.is_trader(&trader1));
-    assert!(client.is_trader(&trader2));
-}
-
-// ── Role Exclusivity ───────────────────────────────────────────────────────────
-
-#[test]
-fn test_verifier_cannot_be_added_as_trader() {
-    let (env, client, _) = setup();
-    let addr = Address::generate(&env);
-
-    client.add_verifier(&addr);
-    let result = client.try_add_trader(&addr);
-    assert_eq!(result, Err(Ok(Error::AddressHasDifferentRole)));
-}
-
-#[test]
-fn test_trader_cannot_be_added_as_verifier() {
-    let (env, client, _) = setup();
-    let addr = Address::generate(&env);
-
-    client.add_trader(&addr);
-    let result = client.try_add_verifier(&addr);
-    assert_eq!(result, Err(Ok(Error::AddressHasDifferentRole)));
-}
-
-#[test]
-fn test_super_admin_cannot_be_added_as_trader() {
-    let (_, client, super_admin) = setup();
-    let result = client.try_add_trader(&super_admin);
-    assert_eq!(result, Err(Ok(Error::AddressHasDifferentRole)));
-}
-
-// ── has_role (cross-contract interface) ────────────────────────────────────────
-
-#[test]
-fn test_has_role_verifier() {
-    let (env, client, _) = setup();
-    let verifier = Address::generate(&env);
-
-    client.add_verifier(&verifier);
+    // Grant roles
+    client.grant_verifier(&super_admin, &verifier);
+    client.grant_trader(&super_admin, &trader);
+    client.grant_admin(&super_admin, &admin);
 
     assert!(client.has_role(&verifier, &String::from_str(&env, "Verifier")));
-    assert!(!client.has_role(&verifier, &String::from_str(&env, "Trader")));
-    assert!(!client.has_role(&verifier, &String::from_str(&env, "Admin")));
-}
-
-#[test]
-fn test_has_role_trader() {
-    let (env, client, _) = setup();
-    let trader = Address::generate(&env);
-
-    client.add_trader(&trader);
-
     assert!(client.has_role(&trader, &String::from_str(&env, "Trader")));
-    assert!(!client.has_role(&trader, &String::from_str(&env, "Verifier")));
+    assert!(client.has_role(&admin, &String::from_str(&env, "Admin")));
+
+    assert_eq!(client.get_role(&verifier), 1u32);
+    assert_eq!(client.get_role(&trader), 2u32);
+    assert_eq!(client.get_role(&admin), 3u32);
+
+    // Revoke role
+    client.revoke_role(&super_admin, &verifier);
+    assert!(!client.has_role(&verifier, &String::from_str(&env, "Verifier")));
+
+    // SuperAdmin cannot be revoked directly
+    let res = client.try_revoke_role(&super_admin, &super_admin);
+    assert_eq!(res, Err(Ok(Error::CannotRemoveSuperAdmin)));
+}
+
+// ── Batch Operations (Single Admin Mode) ──────────────────────────────────────
+
+#[test]
+fn test_batch_operations_single_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, super_admin) = setup_single(&env);
+
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+
+    let assignments = vec![
+        &env,
+        (user1.clone(), Symbol::new(&env, "Verifier")),
+        (user2.clone(), Symbol::new(&env, "Trader")),
+    ];
+
+    client.assign_roles_batch(&super_admin, &assignments);
+    assert!(client.has_role(&user1, &String::from_str(&env, "Verifier")));
+    assert!(client.has_role(&user2, &String::from_str(&env, "Trader")));
+
+    let revocations = vec![
+        &env,
+        (user1.clone(), Symbol::new(&env, "Verifier")),
+        (user2.clone(), Symbol::new(&env, "Trader")),
+    ];
+    client.revoke_roles_batch(&super_admin, &revocations);
+    assert!(!client.has_role(&user1, &String::from_str(&env, "Verifier")));
+    assert!(!client.has_role(&user2, &String::from_str(&env, "Trader")));
 }
 
 #[test]
-fn test_has_role_super_admin() {
-    let (env, client, super_admin) = setup();
-    assert!(client.has_role(&super_admin, &String::from_str(&env, "Admin")));
-    assert!(!client.has_role(&super_admin, &String::from_str(&env, "Verifier")));
-}
+fn test_transfer_admin_single_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, super_admin) = setup_single(&env);
 
-#[test]
-fn test_has_role_unknown_address_is_false() {
-    let (env, client, _) = setup();
-    let nobody = Address::generate(&env);
-    assert!(!client.has_role(&nobody, &String::from_str(&env, "Verifier")));
-    assert!(!client.has_role(&nobody, &String::from_str(&env, "Admin")));
-    assert!(!client.has_role(&nobody, &String::from_str(&env, "Trader")));
-}
-
-// ── transfer_admin ─────────────────────────────────────────────────────────────
-
-#[test]
-fn test_transfer_admin() {
-    let (env, client, old_admin) = setup();
     let new_admin = Address::generate(&env);
+    client.transfer_admin(&new_admin);
 
-    client.transfer_admin(&old_admin, &new_admin);
     assert_eq!(client.get_super_admin(), new_admin);
-    assert!(client.is_super_admin(&new_admin));
-    assert!(!client.is_super_admin(&old_admin));
+    assert!(client.has_role(&new_admin, &String::from_str(&env, "SuperAdmin")));
+    assert!(!client.has_role(&super_admin, &String::from_str(&env, "SuperAdmin")));
+}
+
+// ── Multi-Sig Proposal Flow Tests ─────────────────────────────────────────────
+
+#[test]
+fn test_multi_sig_immediate_execution_on_threshold_1() {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    // threshold = 1, delay = 0
+    let (client, admins) = setup_multi(&env, 1, 0);
+    let admin1 = admins.get(0).unwrap();
+    let user = Address::generate(&env);
+
+    let action = ProposalAction::GrantAdmin(user.clone());
+    let proposal_id = client.propose_action(&admin1, &action);
+
+    // Should be executed immediately
+    let proposal = client.get_proposal(&proposal_id).unwrap();
+    assert!(proposal.executed);
+    assert!(client.is_admin(&user));
+}
+
+#[test]
+fn test_multi_sig_proposal_and_approval_threshold_2() {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    // threshold = 2, delay = 0
+    let (client, admins) = setup_multi(&env, 2, 0);
+    let admin1 = admins.get(0).unwrap();
+    let admin2 = admins.get(1).unwrap();
+    let user = Address::generate(&env);
+
+    let action = ProposalAction::GrantAdmin(user.clone());
+    
+    // Propose (adds 1st approval from admin1)
+    let proposal_id = client.propose_action(&admin1, &action);
+    let mut proposal = client.get_proposal(&proposal_id).unwrap();
+    assert!(!proposal.executed);
+    assert_eq!(proposal.approvals.len(), 1);
+
+    // Try executing directly - fails (insufficient approvals)
+    let res_exec = client.try_execute_proposal(&proposal_id);
+    assert_eq!(res_exec, Err(Ok(Error::InsufficientApprovals)));
+
+    // Approve by same admin fails
+    let res_dup = client.try_approve_proposal(&admin1, &proposal_id);
+    assert_eq!(res_dup, Err(Ok(Error::AlreadyApproved)));
+
+    // Approve by admin2 (adds 2nd approval)
+    client.approve_proposal(&admin2, &proposal_id);
+    proposal = client.get_proposal(&proposal_id).unwrap();
+    assert_eq!(proposal.approvals.len(), 2);
+
+    // Execute proposal
+    client.execute_proposal(&proposal_id);
+    proposal = client.get_proposal(&proposal_id).unwrap();
+    assert!(proposal.executed);
+    assert!(client.is_admin(&user));
+}
+
+#[test]
+fn test_multi_sig_rejection() {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    let (client, admins) = setup_multi(&env, 2, 0);
+    let admin1 = admins.get(0).unwrap();
+    let admin2 = admins.get(1).unwrap();
+    let user = Address::generate(&env);
+
+    let action = ProposalAction::GrantAdmin(user.clone());
+    let proposal_id = client.propose_action(&admin1, &action);
+
+    // Reject proposal
+    client.reject_proposal(&admin2, &proposal_id);
+    let proposal = client.get_proposal(&proposal_id).unwrap();
+    assert!(proposal.rejected);
+
+    // Try approving rejected proposal fails
+    let res_app = client.try_approve_proposal(&admin2, &proposal_id);
+    assert_eq!(res_app, Err(Ok(Error::ProposalRejected)));
+
+    // Try executing rejected proposal fails
+    let res_exec = client.try_execute_proposal(&proposal_id);
+    assert_eq!(res_exec, Err(Ok(Error::ProposalRejected)));
+}
+
+#[test]
+fn test_multi_sig_timelock_delay() {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    // threshold = 2, delay = 100 seconds
+    let (client, admins) = setup_multi(&env, 2, 100);
+    let admin1 = admins.get(0).unwrap();
+    let admin2 = admins.get(1).unwrap();
+    let user = Address::generate(&env);
+
+    // Set initial ledger time
+    env.ledger().set_timestamp(1000);
+
+    let action = ProposalAction::GrantAdmin(user.clone());
+    let proposal_id = client.propose_action(&admin1, &action);
+    client.approve_proposal(&admin2, &proposal_id);
+
+    // Try executing immediately at t=1000 - fails (timelock not expired)
+    let res_early = client.try_execute_proposal(&proposal_id);
+    assert_eq!(res_early, Err(Ok(Error::TimelockNotExpired)));
+
+    // Set time to t=1099 - still fails
+    env.ledger().set_timestamp(1099);
+    let res_almost = client.try_execute_proposal(&proposal_id);
+    assert_eq!(res_almost, Err(Ok(Error::TimelockNotExpired)));
+
+    // Set time to t=1100 - succeeds!
+    env.ledger().set_timestamp(1100);
+    client.execute_proposal(&proposal_id);
+    
+    let proposal = client.get_proposal(&proposal_id).unwrap();
+    assert!(proposal.executed);
+    assert!(client.is_admin(&user));
+}
+
+#[test]
+fn test_change_super_admins_via_proposal() {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    let (client, admins) = setup_multi(&env, 2, 0);
+    let admin1 = admins.get(0).unwrap();
+    let admin2 = admins.get(1).unwrap();
+
+    let new_admin1 = Address::generate(&env);
+    let new_admin2 = Address::generate(&env);
+    let new_admins = vec![&env, new_admin1.clone(), new_admin2.clone()];
+
+    let action = ProposalAction::ChangeSuperAdmins {
+        admins: new_admins,
+        threshold: 2,
+    };
+
+    let proposal_id = client.propose_action(&admin1, &action);
+    client.approve_proposal(&admin2, &proposal_id);
+    client.execute_proposal(&proposal_id);
+
+    // Verify new super admins are active
+    assert!(client.has_role(&new_admin1, &String::from_str(&env, "SuperAdmin")));
+    assert!(client.has_role(&new_admin2, &String::from_str(&env, "SuperAdmin")));
+
+    // Verify old super admins are revoked
+    assert!(!client.has_role(&admin1, &String::from_str(&env, "SuperAdmin")));
 }


### PR DESCRIPTION
- Closes #47 

I implemented an N-of-M multi-sig proposal system with optional timelock delays in the `RbacContract` to replace the single-address SuperAdmin setup.

# What Changed:
1.  Multi-Sig & Delay Storage (storage.rs):  Added state to store `SuperAdmins` (list of addresses), the approval `SuperAdminThreshold`, optional `TimelockDelay` (in seconds), and on-chain governance proposals.
2.  Governance API (lib.rs):  Added `propose_action`, `approve_proposal`, `execute_proposal`, and `reject_proposal` to control critical actions (like changing SuperAdmins, updating timelock, batching roles, and admin changes).
3. 
4.  Developer UX & Backward Compatibility:
    *   Preserved existing `get_super_admin` and `transfer_admin` signatures.
    *   Immediate Execution: If threshold is `1` and delay is `0` (default dev/test setup), actions execute immediately upon proposal creation to keep development frictionless.
    *   Direct admin batch calls now reject unilaterally when threshold is greater than 1, forcing proposal flow.
5.  Expanded Tests ([test.rs] & [integration_test.rs:  Rewrote the test suite to verify immediate execution (1-of-1), threshold checks (2-of-3 approvals), timelock delay enforcement, and proposal cancellations.